### PR TITLE
Object destruction logging message added

### DIFF
--- a/Cmakelists.txt
+++ b/Cmakelists.txt
@@ -90,17 +90,20 @@ if(MSVC) # If using the VS compiler...
 endif()
 
 ####################### Include directories #######################
+
+# internal headers include
 target_include_directories("${CMAKE_PROJECT_NAME}" PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Source/Vulkan/Public")
 target_include_directories("${CMAKE_PROJECT_NAME}" PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Source/Global/Public")
 target_include_directories("${CMAKE_PROJECT_NAME}" PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Source/Data/Public")
 target_include_directories("${CMAKE_PROJECT_NAME}" PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Source/Templates/")
 target_include_directories("${CMAKE_PROJECT_NAME}" PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Source/Commons/")
 
-target_include_directories(${PROJECT_NAME} PUBLIC ${Vulkan_INCLUDE_DIRS}) # include vulkan headers
-target_include_directories(${PROJECT_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/DirectXMath/Inc")
-target_include_directories(${PROJECT_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/stb/")
+# third party include
+target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC ${Vulkan_INCLUDE_DIRS}) # include vulkan headers
+target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/DirectXMath/Inc")
+target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/stb/")
 
-#enet not working yet on linux for some reason
+# link libraries
 target_link_libraries("${CMAKE_PROJECT_NAME}" PRIVATE glfw ${Vulkan_LIBRARIES})
 
 ####################### HLSL Shader build #######################

--- a/Source/Commons/Utilities.h
+++ b/Source/Commons/Utilities.h
@@ -1,14 +1,16 @@
 #pragma once
 
-// vulkan
-#include <vulkan/vulkan.h>
+// third-party
+#include <vulkan/vulkan.h> // vulkan
 
 // std
 #include <iostream>
 #include <fstream>
 #include <vector>
+#include <unordered_map>
+#include <unordered_set>
 #include <set>
-#include <memory> // for smart pointers
+#include <memory>
 #include <algorithm>
 #include <array>
 #include <string>

--- a/Source/Vulkan/Private/MKCommandService.cpp
+++ b/Source/Vulkan/Private/MKCommandService.cpp
@@ -8,6 +8,10 @@ MKCommandService::MKCommandService()
 MKCommandService::~MKCommandService()
 {
 	vkDestroyCommandPool(_mkDevicePtr->GetDevice(), _vkCommandPool, nullptr);
+
+#ifndef NDEBUG
+	std::clog << "[MURAKANO] : command pool destroyed" << std::endl;
+#endif
 }
 
 void MKCommandService::InitCommandService(MKDevice* mkDevicePtr)

--- a/Source/Vulkan/Private/MKDescriptorManager.cpp
+++ b/Source/Vulkan/Private/MKDescriptorManager.cpp
@@ -147,6 +147,15 @@ MKDescriptorManager::~MKDescriptorManager()
 
     // destroy descriptor set layout
     vkDestroyDescriptorSetLayout(_mkDeviceRef.GetDevice(), _vkDescriptorSetLayout, nullptr);
+
+#ifndef NDEBUG
+    std::clog << "[MURAKANO] : combined image sampler destroyed" << std::endl;
+    std::clog << "[MURAKANO] : texture image view destroyed" << std::endl;
+    std::clog << "[MURAKANO] : texture image destroyed and freed its memory" << std::endl;
+    std::clog << "[MURAKANO] : uniform buffer objects destroyed" << std::endl;
+    std::clog << "[MURAKANO] : descriptor pool destroyed" << std::endl;
+    std::clog << "[MURAKANO] : descriptor set layout destroyed" << std::endl;
+#endif
 }
 
 void MKDescriptorManager::UpdateUniformBuffer(uint32 currentFrame)

--- a/Source/Vulkan/Private/MKDevice.cpp
+++ b/Source/Vulkan/Private/MKDevice.cpp
@@ -36,17 +36,13 @@ MKDevice::MKDevice(MKWindow& windowRef,const MKInstance& instanceRef)
 	deviceCreateInfo.pEnabledFeatures = &deviceFeatures;										       // device features
 	deviceCreateInfo.enabledExtensionCount = SafeStaticCast<size_t, uint32>(deviceExtensions.size());  // number of device extensions
 	deviceCreateInfo.ppEnabledExtensionNames = deviceExtensions.data();							       // device extensions
-	if (ENABLE_VALIDATION_LAYERS) 
-	{
-		deviceCreateInfo.enabledLayerCount = SafeStaticCast<size_t, uint32>(validationLayers.size());
-		deviceCreateInfo.ppEnabledLayerNames = validationLayers.data();
-	}
-	else
-	{
-		deviceCreateInfo.enabledLayerCount = 0;													        // number of layers
-		deviceCreateInfo.ppEnabledLayerNames = nullptr;											        // layers
-	}
-
+#ifdef NDEBUG
+	deviceCreateInfo.enabledLayerCount = 0;													        // number of layers
+	deviceCreateInfo.ppEnabledLayerNames = nullptr;											        // layers
+#else
+	deviceCreateInfo.enabledLayerCount = SafeStaticCast<size_t, uint32>(validationLayers.size());
+	deviceCreateInfo.ppEnabledLayerNames = validationLayers.data();
+#endif
 	if (vkCreateDevice(_vkPhysicalDevice, &deviceCreateInfo, nullptr, &_vkLogicalDevice) != VK_SUCCESS)
 	{
 		throw std::runtime_error("failed to create logical device!");
@@ -66,6 +62,12 @@ MKDevice::~MKDevice()
 
 	vkDestroySurfaceKHR(_mkInstanceRef.GetVkInstance(), _vkSurface, nullptr);
 	vkDestroyDevice(_vkLogicalDevice, nullptr);
+
+#ifndef NDEBUG
+	std::clog << "[MURAKANO] : global command service instance destroyed" << std::endl;
+	std::clog << "[MURAKANO] : surface extension destroyed" << std::endl;
+	std::clog << "[MURAKANO] : logical device destroyed" << std::endl;
+#endif
 }
 
 void MKDevice::PickPhysicalDevice()

--- a/Source/Vulkan/Private/MKGraphicsPipeline.cpp
+++ b/Source/Vulkan/Private/MKGraphicsPipeline.cpp
@@ -186,6 +186,13 @@ MKGraphicsPipeline::~MKGraphicsPipeline()
 	// destroy pipeline and pipeline layout
 	vkDestroyPipeline(_mkDeviceRef.GetDevice(), _vkGraphicsPipeline, nullptr);
 	vkDestroyPipelineLayout(_mkDeviceRef.GetDevice(), _vkPipelineLayout, nullptr);
+
+#ifndef NDEBUG
+	std::clog << "[MURAKANO] : index buffer destroyed and memory freed" << std::endl;
+	std::clog << "[MURAKANO] : vertex buffer destroyed and memory freed" << std::endl;
+	std::clog << "[MURAKANO] : sync objects destroyed" << std::endl;
+	std::clog << "[MURAKANO] : graphics pipeline and its layout destroyed" << std::endl;
+#endif
 }
 
 void MKGraphicsPipeline::RecordFrameBuffferCommand(uint32 swapchainImageIndex)

--- a/Source/Vulkan/Private/MKRenderPass.cpp
+++ b/Source/Vulkan/Private/MKRenderPass.cpp
@@ -82,4 +82,8 @@ MKRenderPass::MKRenderPass(const MKDevice& mkDeviceRef, VkFormat swapchainImageF
 MKRenderPass::~MKRenderPass()
 {
 	vkDestroyRenderPass(_mkDeviceRef.GetDevice(), _vkRenderPass, nullptr);
+
+#ifndef NDEBUG
+	std::clog << "[MURAKANO] : render pass destroyed" << std::endl;
+#endif
 }

--- a/Source/Vulkan/Private/MKSwapchain.cpp
+++ b/Source/Vulkan/Private/MKSwapchain.cpp
@@ -19,6 +19,11 @@ MKSwapchain::MKSwapchain(MKDevice& deviceRef)
 MKSwapchain::~MKSwapchain()
 {
 	DestroySwapchainResources();
+#ifndef NDEBUG
+	std::clog << "[MURAKANO] : VkFramebuffer destroyed" << std::endl;
+	std::clog << "[MURAKANO] : swapchain image view destroyed" << std::endl;
+	std::clog << "[MURAKANO] : swapchin extension destroyed" << std::endl;
+#endif
 }
 
 void MKSwapchain::DestroySwapchainResources()

--- a/Source/Vulkan/Private/MKValidationLayer.cpp
+++ b/Source/Vulkan/Private/MKValidationLayer.cpp
@@ -3,9 +3,11 @@
 MKValidationLayer::MKValidationLayer()
     : _debugMessenger(VK_NULL_HANDLE)
 {
-    if (ENABLE_VALIDATION_LAYERS && !CheckValidationLayerSupport()) {
+#ifndef NDEBUG
+    if (!CheckValidationLayerSupport()) {
 		throw std::runtime_error("validation layers requested, but not available.");
 	}
+#endif
 }
 
 MKValidationLayer::~MKValidationLayer() {}
@@ -38,7 +40,9 @@ bool MKValidationLayer::CheckValidationLayerSupport()
 
 void MKValidationLayer::SetupDebugMessenger(VkInstance instance)
 {
-    if (!ENABLE_VALIDATION_LAYERS) return;
+#ifdef NDEBUG
+    return;
+#endif
 
     VkDebugUtilsMessengerCreateInfoEXT debugMessengerInfo{};
     PopulateDebugMessengerCreateInfo(debugMessengerInfo);

--- a/Source/Vulkan/Private/MKWindow.cpp
+++ b/Source/Vulkan/Private/MKWindow.cpp
@@ -14,6 +14,10 @@ MKWindow::~MKWindow()
 {
     glfwDestroyWindow(_window);
     glfwTerminate();
+
+#ifndef NDEBUG
+    std::clog << "[MURAKANO] : glfw window destroyed" << std::endl;
+#endif
 }
 
 void MKWindow::framebufferResizeCallback(GLFWwindow* window, int width, int height)

--- a/Source/Vulkan/Public/MKValidationLayer.h
+++ b/Source/Vulkan/Public/MKValidationLayer.h
@@ -1,11 +1,5 @@
 #pragma once
 
-#ifdef NDEBUG
- #define ENABLE_VALIDATION_LAYERS 0
-#else
- #define ENABLE_VALIDATION_LAYERS 1
-#endif
-
 #include "Utilities.h"
 
 const std::vector<const char*> validationLayers = {


### PR DESCRIPTION
Following the existencne of NDEBUG compile definition, now murakano supports object destruction logging message dynamically.