### PR TITLE
Implement descriptor manager API

### DIFF
--- a/Source/Commons/Public/VulkanType.h
+++ b/Source/Commons/Public/VulkanType.h
@@ -17,10 +17,3 @@ struct VkImageAllocated
 	VkImage        image;
 	VmaAllocation  allocation;
 };
-
-// a struct to wrap a VkDescriptorType and its ratio in pool
-struct VkDescriptorPoolSizeRatio
-{
-	VkDescriptorType  type;
-	float             ratio; // ratio of the individual descriptor type in the pool
-};

--- a/Source/Vulkan/Public/MKDescriptorManager.h
+++ b/Source/Vulkan/Public/MKDescriptorManager.h
@@ -14,81 +14,54 @@ class MKDescriptorManager
 public:
 	MKDescriptorManager();
 	~MKDescriptorManager();
-	void InitDescriptorManager(MKDevice* mkDevicePtr, VkExtent2D swapchainExtent);
-
-	/* getters */
-	VkDescriptorSetLayout*  GetDescriptorSetLayoutPtr() { return &_vkDescriptorSetLayout; }
-	VkDescriptorSet*        GetDescriptorSetPtr(uint32 currentFrame) { return &_vkDescriptorSets[currentFrame]; }
-	VkImageView             GetDepthImageView() const { return _vkDepthImageView; }
-
-	/* undate uniform buffer objects state*/
-	void UpdateUniformBuffer(uint32 currentFrame);
-	
-	/* update swapchain extent whenever there is recreation of it. */
-	void UpdateSwapchainExtent(VkExtent2D swapchainExtent) { _vkSwapchainExtent = swapchainExtent; }
+	void InitDescriptorManager(MKDevice* mkDevicePtr);
 
 	/* commands - transition image layout with pipeline barrier (when VK_SHARING_MODE_EXCLUSIVE) */
 	void TransitionImageLayout(VkCommandBuffer commandBuffer, VkImage image, VkFormat format, VkImageLayout oldLayout, VkImageLayout newLayout);
 	void CopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer buffer, VkImage image, uint32_t width, uint32_t height); 
 
-	/* api */
-	VkDescriptorPool GetDescriptorPool();
-	VkDescriptorSet AllocateDescriptorSet(VkDescriptorSetLayout layout);
-	void AddDescriptorSetLayoutBinding(VkDescriptorType descriptorType, VkShaderStageFlags shaderStageFlags, uint32_t binding, uint32_t descriptorCount);
-	VkDescriptorSetLayout CreateDescriptorSetLayout();
-	VkDescriptorPool CreateDescriptorPool(std::vector<VkDescriptorPoolSizeRatio> descriptorPoolSizeRatios, uint32 setCount);
-	void ResetDescriptorPool();
+	/* descriptor manager api */
+	VkDescriptorPool       GetDescriptorPool();
+	VkDescriptorPool       CreateDescriptorPool(uint32 setCount);
+	void                   AddDescriptorSetLayoutBinding(VkDescriptorType descriptorType, VkShaderStageFlags shaderStageFlags, uint32_t binding, uint32_t descriptorCount);
+	void                   CreateDescriptorSetLayout(VkDescriptorSetLayout& layout);
+	void                   AllocateDescriptorSet(std::vector<VkDescriptorSet>& descriptorSets, VkDescriptorSetLayout layout);
+	void                   WriteBufferToDescriptorSet(VkBuffer buffer, VkDeviceSize offset, VkDeviceSize range, uint32 dstBinding, VkDescriptorType descriptorType);
+	void                   WriteImageToDescriptorSet(VkImageView imageView, VkSampler imageSampler, VkImageLayout imageLayout, uint32 dstBinding, VkDescriptorType descriptorType);
+	void                   UpdateDescriptorSet(VkDescriptorSet descriptorSet);
+	void                   ResetDescriptorPool();
 
 	/* create resources */
 	void CreateTextureImage(const std::string texturePath, VkImageAllocated& textureImage);
 	void CreateTextureImageView(VkImage& textureImage, VkImageView& textureImageView);
-	void CreateTextureSampler();
-	void CreateDepthResources();
+	void CreateTextureSampler(VkSampler& textureSampler);
 
 	/* destroy resources */
 	void DestroyTextureImage(VkImageAllocated textureImage) { vmaDestroyImage(_mkDevicePtr->GetVmaAllocator(), textureImage.image, textureImage.allocation); }
 	void DestroyTextureImageView(VkImageView textureImageView) { vkDestroyImageView(_mkDevicePtr->GetDevice(), textureImageView, nullptr); }
 	void DestroyTextureSampler(VkSampler textureSampler) { vkDestroySampler(_mkDevicePtr->GetDevice(), textureSampler, nullptr); } 
-	void DestroyDepthResources();
 
 private:
-	/* create uniform buffer object*/
-	void CreateUniformBuffer();
-
 	/* create depth buffer resources */
 	bool HasStencilComponent(VkFormat format) { return format == VK_FORMAT_D32_SFLOAT_S8_UINT || format == VK_FORMAT_D24_UNORM_S8_UINT; }
 
 
 private:
 	/* descriptor pool */
-	VkDescriptorPool _vkDescriptorPool = VK_NULL_HANDLE;
+	std::vector<VkDescriptorPoolSize>       _vkDescriptorPoolSizes = {
+		{VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,         MAX_FRAMES_IN_FLIGHT},
+		{VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, MAX_FRAMES_IN_FLIGHT}
+	};
+	std::vector<VkDescriptorSetLayoutBinding>                   _vkWaitingBindings = std::vector<VkDescriptorSetLayoutBinding>();
+	std::unordered_set<std::shared_ptr<VkDescriptorBufferInfo>> _vkWaitingBufferInfos = std::unordered_set<std::shared_ptr<VkDescriptorBufferInfo>>();
+	std::unordered_set<std::shared_ptr<VkDescriptorImageInfo>>  _vkWaitingImageInfos = std::unordered_set<std::shared_ptr<VkDescriptorImageInfo>>();
+	std::vector<VkWriteDescriptorSet>                           _vkWaitingWrites = std::vector<VkWriteDescriptorSet>();
 
-	std::vector<VkDescriptorSetLayoutBinding> _vkWaitingBindings;
+	std::vector<VkDescriptorPool>                               _vkDescriptorPoolReady; // available descriptor pool
+	std::vector<VkDescriptorPool>                               _vkDescriptorPoolFull;  // full descriptor pool 
 
-	std::vector<VkDescriptorPoolSizeRatio>  _vkDescriptorPoolSizeRatios;
-	std::vector<VkDescriptorPool>           _vkDescriptorPoolReady;
-	std::vector<VkDescriptorPool>           _vkDescriptorPoolFull;
-
-	/* uniform buffer descriptor*/
-	VkDescriptorSetLayout         _vkDescriptorSetLayout = VK_NULL_HANDLE;
-	std::vector<VkBufferAllocated>_vkUniformBuffers = std::vector<VkBufferAllocated>();
-	std::vector<void*>            _vkUniformBuffersMapped = std::vector<void*>();
-	std::vector<VkDescriptorSet>  _vkDescriptorSets = std::vector<VkDescriptorSet>();
-
-	/* extent reference */
-	VkExtent2D                    _vkSwapchainExtent = VkExtent2D{ 0, 0 };
-
-	/* texture resources */
-	VkImageAllocated              _vkTextureImage;
-	VkImageView                   _vkTextureImageView = VK_NULL_HANDLE;
-	VkSampler                     _vkTextureSampler = VK_NULL_HANDLE;
-
-	/* depth buffer resources */
-	VkImageAllocated              _vkDepthImage;
-	VkImageView                   _vkDepthImageView = VK_NULL_HANDLE;
-
-	/* default set count per pool */
-	uint32                        _setsPerPool = 100;
+	/* max set count per pool */
+	uint32 _setsPerPool = 100; // default is 100, max is 4092
 
 private:
 	MKDevice* _mkDevicePtr = nullptr;

--- a/Source/Vulkan/Public/MKSwapchain.h
+++ b/Source/Vulkan/Public/MKSwapchain.h
@@ -21,20 +21,22 @@ public:
 public:
 	/* getters */
 	VkSwapchainKHR GetSwapchain()			           const { return _vkSwapchain; }
-	VkFormat	   GetSwapchainImageFormat()           const { return _vkSwapchainImageFormat; }
-	VkExtent2D	   GetSwapchainExtent()	               const { return _vkSwapchainExtent; }
+	VkFormat       GetSwapchainImageFormat()           const { return _vkSwapchainImageFormat; }
+	VkExtent2D     GetSwapchainExtent()	               const { return _vkSwapchainExtent; }
 	VkFramebuffer  GetFramebuffer(uint32 imageIndex)   const { return _vkSwapchainFramebuffers[imageIndex]; }
 	VkRenderPass   RequestRenderPass()                 const { return _mkRenderPassPtr->GetRenderPass(); }
 
 	/* setters */
-	void		   RequestFramebufferResize(bool isResized) { _mkDeviceRef.SetFrameBufferResized(isResized); }
-	void           DestroySwapchainResources();
-	void           RecreateSwapchain();
+	void RequestFramebufferResize(bool isResized) { _mkDeviceRef.SetFrameBufferResized(isResized); }
+	void DestroySwapchainResources();
+	void DestroyDepthResources();
+	void RecreateSwapchain();
 
 private:
 	void CreateSwapchain();
 	void CreateSwapchainImageViews();
 	void CreateFrameBuffers();
+	void CreateDepthResources();
 
 private:
 	VkSwapchainKHR				_vkSwapchain;
@@ -43,6 +45,8 @@ private:
 	std::vector<VkFramebuffer>  _vkSwapchainFramebuffers;
 	VkFormat					_vkSwapchainImageFormat;
 	VkExtent2D					_vkSwapchainExtent;
+	VkImageAllocated            _vkDepthImage;
+	VkImageView                 _vkDepthImageView;
 		
 private:
 	MKDevice&					   _mkDeviceRef;

--- a/Source/Vulkan/Public/MkGraphicsPipeline.h
+++ b/Source/Vulkan/Public/MkGraphicsPipeline.h
@@ -25,33 +25,57 @@ public:
 
 private:
 	VkShaderModule  CreateShaderModule(const std::vector<char>& code);
+    /* create synchronization objects */
     void            CreateSyncObjects();
     /* actual buffer creation logic */
     void            CreateVertexBuffer();
     /* index buffer creation*/
     void            CreateIndexBuffer();
+    /* uniform buffer creation */
+    void            CreateUniformBuffers();
     /* Frame buffer commands recording and calling command service interfaces */
     void            RecordFrameBuffferCommand(uint32 swapchainImageIndex);
     /* copy source buffer to destination buffer */
     void            CopyBufferToBuffer(VkBufferAllocated src, VkBufferAllocated dest, VkDeviceSize size);
+    /* update uniform buffer */
+    void            UpdateUniformBuffer();
+    /* create texture resources */
+    void            CreateTextureResources();
 
 private:
     /* pipeline instance */
-	VkPipeline	              _vkGraphicsPipeline;
-	VkPipelineLayout          _vkPipelineLayout;
+	VkPipeline	      _vkGraphicsPipeline;
+	VkPipelineLayout  _vkPipelineLayout;
+    
     /* sync objects */
     std::vector<VkSemaphore>  _vkImageAvailableSemaphores;
     std::vector<VkSemaphore>  _vkRenderFinishedSemaphores;
     std::vector<VkFence>      _vkInFlightFences;
+    
     /* vertex buffer */
-    VkBufferAllocated         _vkVertexBuffer;
+    VkBufferAllocated _vkVertexBuffer;
+    
     /* index buffer */
-    VkBufferAllocated         _vkIndexBuffer;
+    VkBufferAllocated _vkIndexBuffer;
 
-    OBJModel                  _vikingRoom;
+    /* texture resources */
+    VkImageAllocated  _vkTextureImage;
+    VkImageView       _vkTextureImageView;
+    VkSampler         _vkTextureSampler;
+
+    /* descriptor set */
+    VkDescriptorSetLayout         _vkDescriptorSetLayout;
+    std::vector<VkDescriptorSet>  _vkDescriptorSets;
+
+    /* uniform buffer objects */
+    std::vector<VkBufferAllocated>  _vkUniformBuffers;
+    std::vector<void*>              _vkUniformBuffersMappedData;
+
+    /* 3d model */
+    OBJModel _vikingRoom;
 
 private:
-	MKDevice&            _mkDeviceRef;
-    MKSwapchain&         _mkSwapchainRef;
-    uint32               _currentFrame = 0;
+	MKDevice&     _mkDeviceRef;
+    MKSwapchain&  _mkSwapchainRef;
+    uint32        _currentFrame = 0;
 };


### PR DESCRIPTION
In the previous implementation, the descriptor usage and its creation logic were strongle coupled to each other so that it was difficult to use this global instance outside of class.
Hence, i implemented a proper descriptor management apis in the class
